### PR TITLE
`nodeName` null when you don't click a link.

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -38,7 +38,7 @@ replaceHTML = (html) ->
 
 extractLink = (event) ->
   link = event.target
-  until link is this or link.nodeName is 'A'
+  until link is document or link.nodeName is 'A'
     link = link.parentNode
   link
 


### PR DESCRIPTION
I noticed this error when you click anywhere that doesn't have a link 
in a `parentNode`

`Uncaught TypeError: Cannot read property 'nodeName' of null`

I believe it's because the `until` loop is going one step too far and 
ends up setting `link` to `null`
