### PR TITLE
Correcting asset path for Sprockets

### DIFF
--- a/test/config.ru
+++ b/test/config.ru
@@ -4,7 +4,7 @@ require 'coffee-script'
 Root = File.expand_path("../..", __FILE__)
 
 Assets = Sprockets::Environment.new do |env|
-  env.append_path Root
+  env.append_path File.join(Root, "lib", "assets", "javascripts")
 end
 
 map "/js" do


### PR DESCRIPTION
You can now to run `rackup` within the `./test` directory. 

Then visit [http://localhost:9292/test/index.html](http://localhost:9292/test/index.html) to test.
