### PR TITLE
Initialize Turbolinks so initial page is 'remembered'

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -90,6 +90,8 @@ browserSupportsPushState = window.history and window.history.pushState and windo
 
 
 if browserSupportsPushState
+  initialize()
+
   window.addEventListener 'popstate', (event) ->
     if event.state?.turbolinks
       fetchReplacement document.location.href
@@ -97,7 +99,6 @@ if browserSupportsPushState
   document.addEventListener 'click', (event) ->
     handleClick event
 
-initialize()
 
 # Call Turbolinks.visit(url) from client code
 @Turbolinks = { visit: visit }


### PR DESCRIPTION
Turbolinks doesn't remember the initial page.
### Steps to reproduce
1. Visit initial page in new tab to ensure new history stack.
   
   `http://localhost:9292/test/index.html`
2. Click on **Other page** link.
3. Click on **Home** link.
4. Hit back once. You should be at `other.html`
5. Hit back again. The url changes to `index.html` but the page stays the same.

Hit forward and back a couple of times to see that the url changes but the page stays the same.

The reason this happens is because line 95 executes only when the `turbolinks` state data is present which currently isn't present for the initial page. All the `initialize` function does is use `replaceState` to set the `turbolinks` state data.
