### PR TITLE
Skip links with data-remote attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Turbolinks makes following links in your web application faster. Instead of lett
 
 This is similar to pjax, but instead of worrying about what element on the page to replace, and tailoring the server-side response to fit, we replace the entire body. This means that you get the bulk of the speed benefits from pjax (no recompiling of the JavaScript or CSS) without having to tailor the server-side response. It just works.
 
-By default, all internal links will be funneled through Turbolinks, but you can opt out by marking links with data-no-turbolink.
+By default, all internal links will be funneled through Turbolinks, but you can opt out by marking links with data-no-turbolink. Additionally, links with data-remote will also be skipped as this will cause the request to be made with an unexpected Accept header (HTML instead of JS).
 
 
 No jQuery or any other framework

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -98,7 +98,7 @@ nonHtmlLink = (link) ->
   link.href.match(/\.[a-z]+$/g) and not link.href.match(/\.html?$/g)
 
 noTurbolink = (link) ->
-  link.getAttribute('data-no-turbolink')?
+  link.getAttribute('data-no-turbolink')? or link.getAttribute('data-remote')?
 
 newTabClick = (event) ->
   event.which > 1 or event.metaKey or event.ctrlKey

--- a/test/index.html
+++ b/test/index.html
@@ -15,6 +15,7 @@
     <li><a href="/test/other.html">Other page</a></li>
     <li><a href="/test/other.html"><span>Wrapped link</span></a></li>
     <li><a href="http://www.google.com/">Cross origin</a></li>
+    <li><a href="/test/other.html" data-remote="true">Link with data-remote=true</a></li>
   </ul>
 </body>
 </html>


### PR DESCRIPTION
Links with the rails default remote: true will be sent with format :js. Turbolinks in order to work sends with Accepts: HTML, which causes default Rails remote links to not work properly
