### PR TITLE
Fix typo in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Like pjax, this naturally only works with browsers capable of pushState. But of 
 Installation
 ------------
 
-1. Add `gem turbolinks` to your Gemfile.
+1. Add `gem 'turbolinks'` to your Gemfile.
 1. Run `bundle install`.
 1. Add `//= require turbolinks` to your Javascript manifest file (usually found at `app/assets/javascripts/application.js`).
 1. Restart your server and you're now using turbolinks!


### PR DESCRIPTION
Fix error if installation instructions are copied/pasted:

```
Undefined local variable or method `turbolinks' for Gemfile
```

Bundler's `#gem` method expects to receive the gem name as a `String`.
