### PR TITLE
Set Accept-Encoding header to fetch compressed data

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -17,6 +17,7 @@ fetchReplacement = (url) ->
   xhr = new XMLHttpRequest
   xhr.open 'GET', url, true
   xhr.setRequestHeader 'Accept', 'text/html, application/xhtml+xml, application/xml'
+  xhr.setRequestHeader 'Accept-Encoding', 'gzip, deflate'
   xhr.onload  = ->
     changePage extractTitleAndBody(xhr.responseText)...
     triggerEvent 'page:load'


### PR DESCRIPTION
HTML compresses well, don't waste the users bandwidth!
