### PR TITLE
Fixed iOS 5 and older safari compatibility

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -108,13 +108,19 @@ createDocument = do ->
   else
     createDocumentUsingWrite
 
-
 handleClick = (event) ->
-  link = extractLink event
+  unless event.defaultPrevented
+    document.removeEventListener 'click', handleAfterClick
+    document.addEventListener 'click', handleAfterClick
 
-  if link.nodeName is 'A' and !ignoreClick(event, link)
-    visit link.href
-    event.preventDefault()
+handleAfterClick = (event) ->
+  unless event.defaultPrevented
+    link = extractLink event
+    if link.nodeName is 'A' and !ignoreClick(event, link)
+      link = extractLink event
+      visit link.href
+      event.preventDefault()
+
 
 extractLink = (event) ->
   link = event.target
@@ -164,8 +170,7 @@ if browserSupportsPushState
     historyState = event.state
     fetchHistory event.state if event.state?.turbolinks
 
-  document.addEventListener 'click', (event) ->
-    handleClick event
+  document.addEventListener 'click', handleClick,true
 
 # Call Turbolinks.visit(url) from client code
 @Turbolinks = {visit}

--- a/test/index.html
+++ b/test/index.html
@@ -15,6 +15,7 @@
     <li><a href="/other.html">Other page</a></li>
     <li><a href="/other.html"><span>Wrapped link</span></a></li>
     <li><a href="http://www.google.com/">Cross origin</a></li>
+    <li><a href="/other.html" onclick="if(!confirm('follow link?')) { return false}">Confirm Fire Order</a></li>
     <li><a href="/dummy.gif?12345">Query Param Image Link</a></li>
     <li><a href="#">Hash link</a></li>
   </ul>


### PR DESCRIPTION
window.history.state not available in iOS5 and some older versions of safari. Created wrappers for pushState and replaceState to maintain a copy of state in historyState.

Solution related to issue #49
