### PR TITLE
fixed same page link

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -144,10 +144,8 @@ newTabClick = (event) ->
   event.which > 1 or event.metaKey or event.ctrlKey
 
 ignoreClick = (event, link) ->
-  samePageLink(link) or crossOriginLink(link) or anchoredLink(link) or
-  nonHtmlLink(link)  or remoteLink(link)      or noTurbolink(link)  or 
-  newTabClick(event)
-
+  crossOriginLink(link) or anchoredLink(link) or nonHtmlLink(link) or
+  remoteLink(link)      or noTurbolink(link)  or newTabClick(event)
 
 browserSupportsPushState =
   window.history and window.history.pushState and window.history.replaceState


### PR DESCRIPTION
Fixes issue #41, simply removing samePage filter on links is fine now. DOM Cache still behaves as expected and traverses normally.
