### PR TITLE
Added more modifiers to newTabClick.

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -139,13 +139,13 @@ remoteLink = (link) ->
 noTurbolink = (link) ->
   link.getAttribute('data-no-turbolink')?
 
-newTabClick = (event) ->
-  event.which > 1 or event.metaKey or event.ctrlKey
+nonStandardClick = (event) ->
+  event.which > 1 or event.metaKey or event.ctrlKey or event.shiftKey or event.altKey
 
 ignoreClick = (event, link) ->
   samePageLink(link) or crossOriginLink(link) or anchoredLink(link) or
   nonHtmlLink(link)  or remoteLink(link)      or noTurbolink(link)  or
-  newTabClick(event)
+  nonStandardClick(event)
 
 
 browserSupportsPushState =


### PR DESCRIPTION
newTabClick only accounted for new tabs and not other situations using other modifiers.

Saw this commit in jquery-pjax while working on caching code. It definitely relates to what we are doing here.

Shift + click:

Safari: add a link to Reading List
Chrome and Firefox: open a link in new window
Alt + click:

Chrome: download a link
Safari: same as Shift + click

Alt + Shift + click:
Safari: download a link

Credit to @NV
