### PR TITLE
Fixing script tag execution

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -52,10 +52,13 @@ constrainPageCacheTo = (limit) ->
 changePage = (title, body) ->
   document.title = title
   document.documentElement.replaceChild body, document.body
-
+  executeScriptTags()
   currentState = window.history.state
   triggerEvent 'page:change'
 
+executeScriptTags = ->
+  scripts = document.body.getElementsByTagName 'script'
+  eval(script.innerHTML) for script in scripts
 
 reflectNewUrl = (url) ->
   if url isnt document.location.href


### PR DESCRIPTION
Related to issue #54,

returned script tags were not being evaluated. New function added called 'executeScriptTags()'
called in changePage() before the page:change event is fired so that any binded listeners added from script tag execution can listen to said event.
