### PR TITLE
Removed cloneNode

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -30,7 +30,7 @@ fetchHistory = (state) ->
   cacheCurrentPage()
 
   if page = pageCache[state.position]
-    changePage page.title, page.body.cloneNode(true)
+    changePage page.title, page.body
     recallScrollPosition page
     triggerEvent 'page:restore'
   else


### PR DESCRIPTION
Since we can now tell the difference between page:change and page:load there is no need to reset the node events using cloneNode.
