### PR TITLE
Only execute script tags that contain Javascript

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -60,7 +60,7 @@ changePage = (title, body) ->
   triggerEvent 'page:change'
 
 executeScriptTags = ->
-  eval(script.innerHTML) for script in document.body.getElementsByTagName 'script'
+  eval(script.innerHTML) for script in document.body.getElementsByTagName 'script' when script.type in ['','text/javascript']
 
 
 reflectNewUrl = (url) ->


### PR DESCRIPTION
Script tags that contain non-Javascript code should not be evaluated with `eval()`.  For example, running `eval()` on client-side templates (like Handlebars) throws syntax errors.  

The solution I came up with was to only run `eval()` if the script tag has no type attribute or the type is set to `text/javascript`:

``` coffeescript
executeScriptTags = ->
  eval(script.innerHTML) for script in document.body.getElementsByTagName 'script' when script.type in ['','text/javascript']
```

Another potential option would be to have turbolinks ignore any script tag with a specific data attribute, like this:

``` html
<script type="text/x-tmpl" data-turbolinks-no-execute>
    // code
</script>
```

``` coffeescript
executeScriptTags = ->
  for script in document.body.getElementsByTagName 'script' 
    eval(script.innerHTML) unless script.getAttribute('data-turbolinks-no-execute')?
```
