### PR TITLE
Asset remembering cannot be lazy

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -96,7 +96,6 @@ rememberInitialPage = ->
   unless initialized
     rememberCurrentUrl()
     rememberCurrentState()
-    rememberCurrentAssets()
     createDocument = browserCompatibleDocumentParser()
     initialized = true
 
@@ -195,6 +194,7 @@ browserSupportsPushState =
   window.history and window.history.pushState and window.history.replaceState and window.history.state != undefined
 
 if browserSupportsPushState
+  rememberCurrentAssets()
   document.addEventListener 'click', installClickHandlerLast, true
 
   window.addEventListener 'popstate', (event) ->


### PR DESCRIPTION
This needs to happen as soon as possible to prevent dynamic scripts from getting checked and added.
