### PR TITLE
Simplify pushState support check

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -4,7 +4,7 @@ referer                  = document.location.href
 assets                   = []
 pageCache                = []
 createDocument           = null
-browserSupportsPushState = window.history?.pushState?
+browserSupportsPushState = window.history?.pushState? and window.history.state isnt undefined
 
 visit = (url) ->
   if browserSupportsPushState


### PR DESCRIPTION
A simpler check would be just the existence of `window.history.pushState`. For example [Modernizr](https://github.com/Modernizr/Modernizr/blob/master/modernizr.js#L514) is doing just that, and they do have a lot of users relying on it, so I believe it should be fine.
