### PR TITLE
Detecting additional asset changes

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -116,7 +116,8 @@ extractAssets = (doc) ->
   (node.src || node.href) for node in doc.head.childNodes when node.src or node.href
 
 assetsChanged = (doc)->
-  intersection(extractAssets(doc), assets).length != assets.length
+  extractedAssets = extractAssets doc
+  extractedAssets.length isnt assets.length or intersection(extractedAssets, assets).length != assets.length
 
 intersection = (a, b) ->
   [a, b] = [b, a] if a.length > b.length


### PR DESCRIPTION
This issue related to #80 . This detects added assets as well now and if this happens forces a reload. It is important to note that in adding this detection it is important for the turbolinks.js file to be the last asset listed in the <head> tag otherwise it will not initially detect the assets included below it.

I would have noted this in the README but not sure where would be best to place this.
