### PR TITLE
Disable for page after failed form submission - Fix #79

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ Since pages will change without a full reload with Turbolinks, you can't by defa
 So if you wanted to have a client-side spinner, you could listen for `page:fetch` to start it and `page:change` to stop it. If you have DOM transformation that are not idempotent (the best way), you can hook them to happen only on `page:load` instead of `page:change` (as that would run them again on the cached pages).
 
 
+Initialization
+--------------
+
+Turbolinks will be enabled **only** if the server has rendered a `GET` request.
+
+Some examples, given a standard RESTful resource:
+
+* `POST :create` => resource successfully created => redirect to `GET :show`
+  * Turbolinks **ENABLED**
+* `POST :create` => resource creation failed => render `:new`
+  * Turbolinks **DISABLED**
+
+**Why not all request types?** Some browsers track the request method of each page load, but triggering pushState methods don't change this value.  This could lead to the situation where pressing the browser's reload button on a page that was fetched with Turbolinks would attempt a `POST` (or something other than `GET`) because the last full page load used that method.
+
+
 Opting out of Turbolinks
 ------------------------
 

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -4,6 +4,7 @@ referer        = document.location.href
 loadedAssets   = null
 pageCache      = {}
 createDocument = null
+requestMethod  = document.cookie.match(/request_method=(\w+)/)?[1].toUpperCase() or ''
 xhr            = null
 
 visit = (url) ->
@@ -215,14 +216,18 @@ ignoreClick = (event, link) ->
   crossOriginLink(link) or anchoredLink(link) or nonHtmlLink(link) or noTurbolink(link) or targetLink(link) or nonStandardClick(event)
 
 
+initializeTurbolinks = ->
+  document.addEventListener 'click', installClickHandlerLast, true
+  window.addEventListener 'popstate', (event) ->
+    fetchHistory event.state if event.state?.turbolinks
+
 browserSupportsPushState =
   window.history and window.history.pushState and window.history.replaceState and window.history.state != undefined
 
-if browserSupportsPushState
-  document.addEventListener 'click', installClickHandlerLast, true
+requestMethodIsSafe = 
+  requestMethod in ['GET','']
 
-  window.addEventListener 'popstate', (event) ->
-    fetchHistory event.state if event.state?.turbolinks
+initializeTurbolinks() if browserSupportsPushState and requestMethodIsSafe
 
 # Call Turbolinks.visit(url) from client code
 @Turbolinks = { visit }

--- a/lib/turbolinks.rb
+++ b/lib/turbolinks.rb
@@ -20,11 +20,18 @@ module Turbolinks
       end
   end
 
+  module Cookies
+    private
+      def set_request_method_cookie
+        cookies[:request_method] = request.request_method
+      end
+  end
+  
   class Engine < ::Rails::Engine
     initializer :turbolinks_xhr_headers do |config|
       ActionController::Base.class_eval do
-        include XHRHeaders
-        before_filter :set_xhr_current_location
+        include XHRHeaders, Cookies
+        before_filter :set_xhr_current_location, :set_request_method_cookie
       end
     end
   end


### PR DESCRIPTION
This is a proposed fix for issue #79.  It's a fair amount of code for such a rare case, but as far as I can tell, it gets rid of the issue.  

When a form is submitted, the form's action is saved in a HTML5 `sessionStorage` key so it can be read (and removed) on the resulting page load.  Turbolinks will then be initialized like normal unless these two conditions are true:
1.  The server did not redirect to a URL different from the form's action, indicating a possible failed submission.  
   -  _if the submitted form's action matches the new document.location.href_
2.  The new page contains a form with the same action as the form that was just submitted, meaning the form was most likely rerendered with errors.

If both of these conditions are true, I chose to have it just skip the creation of the `click` and `popstate` event handlers rather than adding a `data-no-turbolink` attribute to the body.  
