### PR TITLE
Execute external script tags

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -71,7 +71,16 @@ changePage = (title, body) ->
   triggerEvent 'page:change'
 
 executeScriptTags = ->
-  eval(script.innerHTML) for script in document.body.getElementsByTagName 'script' when script.type in ['', 'text/javascript']
+  for script in document.body.getElementsByTagName 'script' when script.type in ['', 'text/javascript']
+    if script.src? and not script.getAttribute('data-turbolinks-evaluated')?
+      copy = document.createElement 'script'
+      copy.setAttribute attr.name, attr.value for attr in script.attributes
+      copy.setAttribute 'data-turbolinks-evaluated', ''
+      parent = script.parentNode
+      parent.removeChild script
+      parent.insertBefore copy, parent.childNodes[0]
+    else
+      eval(script.innerHTML)
 
 
 reflectNewUrl = (url) ->


### PR DESCRIPTION
Related to issue #87.  When evaluating script tags, this handles those with a `src` attribute by copying the element, removing the original, and then inserting the copy into the DOM in the original's place, which triggers a load event on the script.  
