### PR TITLE
rescue ActionDispatch::IllegalStateError

### DIFF
--- a/lib/turbolinks.rb
+++ b/lib/turbolinks.rb
@@ -17,7 +17,6 @@ module Turbolinks
 
       def set_xhr_current_location
         response.headers['X-XHR-Current-Location'] = request.fullpath
-      rescue ActionDispatch::IllegalStateError
       end
   end
 


### PR DESCRIPTION
To be specific:

When using ActionController::Live, the headers may have already been
flushed by the time this is called. Which results in an error.

I'm not actually convinced this is the best way to resolve the issue.
But it is illustrative of an error case that isn't handled.

Anybody have an idea as to what should actually be done in such cases?
