### PR TITLE
Fix assetsChanged

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -118,7 +118,8 @@ extractAssets = (doc) ->
   scripts.concat(stylesheets)
 
 assetsChanged = (doc)->
-  intersection(extractAssets(doc), assets).length != assets.length
+  newAssets = extractAssets(doc)
+  intersection(newAssets, assets).length != newAssets.length
 
 intersection = (a, b) ->
   [a, b] = [b, a] if a.length > b.length


### PR DESCRIPTION
There's two parts to this pull request - the first commit tweaks extractAssets to only consider javascript and stylesheet tags, rather than also considering RSS links, oembed tags etc, as discussed at https://github.com/rails/turbolinks/issues/92.

The second commit I'm less sure about... I think the current logic of assetsChanged is wrong, but perhaps it's too late on a Friday afternoon and my brain has stopped working.   AFAICT, the current behaviour will ignore new scripts - say the current page has scripts A and B, and the new page has A, B, and C, the intersection is just A,B, and so assetsChanged returns false.  @davydotcom, could you take a look?
