### PR TITLE
Fix issue when page doesn't reload if assets changed and the url has a hash param. Ignore target="_blank" links.

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -174,6 +174,9 @@ anchoredLink = (link) ->
   ((link.hash and link.href.replace(link.hash, '')) is location.href.replace(location.hash, '')) or
     (link.href is location.href + '#')
 
+open_in_new_window_link = (link) ->
+  link.getAttribute("target") is "_blank"
+
 nonHtmlLink = (link) ->
   link.href.match(/\.[a-z]+(\?.*)?$/g) and not link.href.match(/\.html?(\?.*)?$/g)
 
@@ -187,7 +190,7 @@ nonStandardClick = (event) ->
   event.which > 1 or event.metaKey or event.ctrlKey or event.shiftKey or event.altKey
 
 ignoreClick = (event, link) ->
-  crossOriginLink(link) or anchoredLink(link) or nonHtmlLink(link) or noTurbolink(link) or nonStandardClick(event)
+  crossOriginLink(link) or anchoredLink(link) or nonHtmlLink(link) or noTurbolink(link) or nonStandardClick(event) or open_in_new_window_link(link)
 
 
 browserSupportsPushState =


### PR DESCRIPTION
This pull request fixes a couple of issues.
- Clicking on a link with hash params when the fetched page has different assets doesn't trigger the reload. This happens because the code first reflects the url and then tries to reload the page if assets changed.
  
  AFAIK window.location.href doesn't reload the page if the url has hash params and is the same as the   current url.
  
  My suggestion is instead of the using document.location.href = new_url, used window.location.reload( ) to trigger the page reload. Another solution would be to first fetch the page and then reflect the new url.
- Links that have the attribute "target" = "_blank" should open in a new browser context (window, tab..).
  To fix this I added another check in the ignore link method.

What are your thoughts on this?
