### PR TITLE
Fix for extractLink()

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -154,7 +154,7 @@ installClickHandlerLast = (event) ->
 handleClick = (event) ->
   unless event.defaultPrevented
     link = extractLink event
-    if link.nodeName is 'A' and !ignoreClick(event, link)
+    if link?.nodeName is 'A' and !ignoreClick(event, link)
       visit link.href
       event.preventDefault()
 


### PR DESCRIPTION
Take into account that parentNode can be nil (orphan node, e.g. previously removed node)
