### PR TITLE
Handle elements removed from dom beter

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -172,7 +172,7 @@ handleClick = (event) ->
 
 extractLink = (event) ->
   link = event.target
-  link = link.parentNode until link is document or !link or link.nodeName is 'A'
+  link = link.parentNode until !link.parentNode or link.nodeName is 'A'
   link
 
 crossOriginLink = (link) ->


### PR DESCRIPTION
Take into account that parentNode can be nil (orphan node, e.g. previously removed node)
