### PR TITLE
Moved `set_xhr_current_location` to before_filter from after_filter

### DIFF
--- a/lib/turbolinks.rb
+++ b/lib/turbolinks.rb
@@ -24,7 +24,7 @@ module Turbolinks
     initializer :turbolinks_xhr_headers do |config|
       ActionController::Base.class_eval do
         include XHRHeaders
-        after_filter :set_xhr_current_location
+        before_filter :set_xhr_current_location
       end
     end
   end


### PR DESCRIPTION
To add `set_xhr_current_location` into after_filter causes `header already sent` error when used with ActionController::Live introduced in Rails4.
