### PR TITLE
start window.history.state.position with Date.now() at rememberCurrentUrl

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -84,7 +84,7 @@ reflectRedirectedUrl = (xhr) ->
     window.history.replaceState currentState, '', location
 
 rememberCurrentUrl = ->
-  window.history.replaceState { turbolinks: true, position: window.history.length - 1 }, '', document.location.href
+  window.history.replaceState { turbolinks: true, position: Date.now() }, '', document.location.href
 
 rememberCurrentState = ->
   currentState = window.history.state


### PR DESCRIPTION
As issued #84, opening different assets page using turbolinks causes continuous the same page loading.
This stems from(as mentioned #84) in some page loading fllow,turbolinks caches a page with wrong state.position id.
Assigning Date.now() as starting window.history.state.position will solve this problem.

Another problem(similar to #84) in Chrome 22, Safari 6:
1. rackup test/config.ru
2. Click 'Asset Change' link
3. Browser back
4. Browser forward
5 Repeat 3, 4 until page never changes(this will occur)
