### PR TITLE
document.location.reload() when assetsChanged

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -26,7 +26,7 @@ fetchReplacement = (url) ->
     doc = createDocument xhr.responseText
 
     if assetsChanged doc
-      document.location.href = url
+      document.location.reload()
     else
       changePage extractTitleAndBody(doc)...
       reflectRedirectedUrl xhr

--- a/test/index.html
+++ b/test/index.html
@@ -19,6 +19,7 @@
     <li><a href="/reload.html"><span>Asset Change</span></a></li>
     <li><a href="/dummy.gif?12345">Query Param Image Link</a></li>
     <li><a href="#">Hash link</a></li>
+    <li><a href="/reload.html#foo">Asset Change with hash link</a></li>
   </ul>
 
   <div style="background:#ccc;height:5000px;width:200px;">


### PR DESCRIPTION
Load asset change page with anchor link fail page changing,
because `reflectNewUrl` changes location but assigning `document.location.href`
with the page url accompanied anchor link dose not make page loading.
This commit fixes the problem.
