### PR TITLE
fix tubro back button handling when window.history.length is > 0 on page load

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -2,7 +2,7 @@ initialized    = false
 currentState   = null
 referer        = document.location.href
 assets         = []
-pageCache      = []
+pageCache      = {}
 createDocument = null
 
 visit = (url) ->
@@ -61,7 +61,8 @@ cacheCurrentPage = ->
   constrainPageCacheTo(10)
 
 constrainPageCacheTo = (limit) ->
-  delete pageCache[currentState.position - limit]
+  for own key, value of pageCache
+    pageCache[key] = null if key <= currentState.position - limit
 
 changePage = (title, body) ->
   document.title = title


### PR DESCRIPTION
... loadIf you navigate to a turbo site from an existing browser session, the window. history.length is > 0. (This is what happens when one reuses a browser window.) 
If window.history.length > 0 when turbo initially loads then turbo’s support for the back button is broken. 

Changing the pageCache from an array to a hash fixes this problem.
