### PR TITLE
rememberCurrentAssets() can only know of assets before turbolinks.

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -130,7 +130,11 @@ assetsChanged = (doc)->
   for asset in extractAssets doc
     newAssets.push asset
     break if asset is assets[-1..][0]
-  newAssets.length isnt assets.length
+  newAssets.length isnt assets.length or intersection(newAssets, assets).length isnt assets.length
+
+intersection = (a, b) ->
+  [a, b] = [b, a] if a.length > b.length
+  value for value in a when value in b
 
 extractTitleAndBody = (doc) ->
   title = doc.querySelector 'title'


### PR DESCRIPTION
Because `rememberCurrentAssets` runs on script load and not DOM ready, it can only extract assets that are included in the page before turbolinks. This will cause a full page reload in Development mode (assuming `config.assets.debug = true`) or if any assets are included after turbolinks with the `javascript_include_tag` or `stylesheet_link_tag` helpers.

This problem was exposed by the update to `assetsChanged` in version 0.5.2.
