### PR TITLE
Minor update

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -165,7 +165,7 @@ installClickHandlerLast = (event) ->
 handleClick = (event) ->
   unless event.defaultPrevented
     link = extractLink event
-    if link?.nodeName is 'A' and !ignoreClick(event, link)
+    if link.nodeName is 'A' and !ignoreClick(event, link)
       visit link.href
       event.preventDefault()
 


### PR DESCRIPTION
extractLink always returns a node, so there is no need to check for presence with `?`
