### PR TITLE
Preserve anchors - Fix #110

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -90,8 +90,8 @@ reflectNewUrl = (url) ->
     window.history.pushState { turbolinks: true, position: currentState.position + 1 }, '', url
 
 reflectRedirectedUrl = (xhr) ->
-  if (location = xhr.getResponseHeader('X-XHR-Current-Location'))
-    window.history.replaceState currentState, '', location
+  unless (location = xhr.getResponseHeader 'X-XHR-Current-Location') is document.location.pathname + document.location.search
+    window.history.replaceState currentState, '', location + document.location.hash
 
 rememberCurrentUrl = ->
   window.history.replaceState { turbolinks: true, position: Date.now() }, '', document.location.href


### PR DESCRIPTION
I came up with a few ways to fix the problem (#110), but I think this one is the best because it takes care of two issues.  

Unless I'm missing something, the purpose of the `reflectRedirectedUrl` function is to update the newly pushed (from `reflectNewUrl`) history state in the event the ajax request is redirected.  However, right now it's doing it whether there was a redirect or not, which most of the time will be unnecessary.  The lost anchors are a side effect of this, since it replaces the current state with the `X-XHR-Current-Location` value from the server (which omits anchors). As far as I can tell, my solution preserves the anchors while eliminating unnecessary replaceState calls.  
