### PR TITLE
Server-side asset tracking

### DIFF
--- a/lib/turbolinks.rb
+++ b/lib/turbolinks.rb
@@ -20,11 +20,40 @@ module Turbolinks
       end
   end
 
+  module AssetTracker
+    private
+      def check_assets
+        cookies.delete :asset_digest
+        yield
+        if response.content_type.include? 'text/html'
+          if request.headers['X-XHR-Asset-Digest']
+            unless asset_digest == request.headers['X-XHR-Asset-Digest']
+              response.headers['X-XHR-Assets-Changed'] = 'true'
+              response.body = '' 
+            end
+          else
+            cookies[:asset_digest] = asset_digest
+          end
+        end
+      end
+      
+      def asset_digest
+        @asset_digest ||= begin
+          assets = []
+          response.body.split('</head>').first.scan /\<(script|link)[\S\s]+?(src|href)="(\S+)"[\S\s]+?\>/ do |type, attr, asset| 
+            assets << asset
+          end
+          Digest::MD5.hexdigest(assets.sort.join)
+        end
+      end
+  end
+  
   class Engine < ::Rails::Engine
     initializer :turbolinks_xhr_headers do |config|
       ActionController::Base.class_eval do
-        include XHRHeaders
+        include XHRHeaders, AssetTracker
         before_filter :set_xhr_current_location
+        around_filter :check_assets
       end
     end
   end


### PR DESCRIPTION
This probably needs work, but I just wanted to throw this idea out there and see if anyone else thinks it could be a viable alternative.  

Potential pros:
- resolves a handful of open issues (like #94 #118)
- eliminates need for turbolinks to be the last line in the application.js manifest
- prevents the double transmission of the entire page over the wire if the assets have changed

Thoughts?
