### PR TITLE
Ignore application.js in test and development environment

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -125,7 +125,7 @@ triggerEvent = (name) ->
 
 extractAssets = (doc) ->
   if railsEnv in ['test', 'development']
-    nodes = (node.src || node.href) for node in doc.head.childNodes when (node.src and !node.src.match(/application.js/)) or node.href
+    nodes = (node.src || node.href) for node in doc.head.childNodes when (node.src and !node.src.match('application.js')) or node.href
   else
     nodes = (node.src || node.href) for node in doc.head.childNodes when node.src or node.href
 

--- a/lib/turbolinks.rb
+++ b/lib/turbolinks.rb
@@ -35,4 +35,3 @@ module Turbolinks
     end
   end
 end
-nd


### PR DESCRIPTION
I think the problem of #118 is that turbolinks does not work in development environment. Today user can use turbolinks only in production environment.

In development environment, the turbolinks' problem is `extractAsstes` detects "application.js" is added in the next page.
By just sending rails environment to the client, client can handle the envoronment difference well.

This commit still requires  turbolinks to be the last line in the application.js manifest,
But I think turbolinks should not use server power as much as possible and should use client power.

For that reason, I will submit pull-req '=require turbolinks' to be bottom of application.js manifest later.

This is related #94 #118 #129 and the design is opposite #129.

I want your thoughts.
