### PR TITLE
Track assets named 'data-turbolinks-track'

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -1,7 +1,7 @@
 initialized    = false
 currentState   = null
 referer        = document.location.href
-assets         = []
+trackingAssets = []
 pageCache      = {}
 createDocument = null
 
@@ -99,8 +99,8 @@ rememberCurrentUrl = ->
 rememberCurrentState = ->
   currentState = window.history.state
 
-rememberCurrentAssets = ->
-  assets = extractAssets document
+rememberCurrentTrackingAssets = ->
+  trackingAssets = extractTrackAssets document
 
 rememberInitialPage = ->
   unless initialized
@@ -121,13 +121,13 @@ triggerEvent = (name) ->
   event.initEvent name, true, true
   document.dispatchEvent event
 
+extractTrackAssets = (doc) ->
+  (node.src || node.href) for node in doc.head.childNodes when node.getAttribute?('data-turbolinks-track')?
 
-extractAssets = (doc) ->
-  (node.src || node.href) for node in doc.head.childNodes when node.src or node.href
 
 assetsChanged = (doc)->
-  extractedAssets = extractAssets doc
-  extractedAssets.length isnt assets.length or intersection(extractedAssets, assets).length != assets.length
+  extractedTrackAssets = extractTrackAssets doc
+  extractedTrackAssets.length isnt trackingAssets.length or intersection(extractedTrackAssets, trackingAssets).length != trackingAssets.length
 
 intersection = (a, b) ->
   [a, b] = [b, a] if a.length > b.length
@@ -205,7 +205,7 @@ browserSupportsPushState =
   window.history and window.history.pushState and window.history.replaceState and window.history.state != undefined
 
 if browserSupportsPushState
-  rememberCurrentAssets()
+  rememberCurrentTrackingAssets()
   document.addEventListener 'click', installClickHandlerLast, true
 
   window.addEventListener 'popstate', (event) ->

--- a/test/index.html
+++ b/test/index.html
@@ -16,10 +16,10 @@
     <li><a href="/other.html"><span>Wrapped link</span></a></li>
     <li><a href="http://www.google.com/">Cross origin</a></li>
     <li><a href="/other.html" onclick="if(!confirm('follow link?')) { return false}">Confirm Fire Order</a></li>
-    <li><a href="/reload.html"><span>Asset Change</span></a></li>
+    <li><a href="/reload.html"><span>New assets track </span></a></li>
     <li><a href="/dummy.gif?12345">Query Param Image Link</a></li>
     <li><a href="#">Hash link</a></li>
-    <li><a href="/reload.html#foo">Asset Change with hash link</a></li>
+    <li><a href="/reload.html#foo">New assets track with hash link</a></li>
   </ul>
 
   <div style="background:#ccc;height:5000px;width:200px;">

--- a/test/reload.html
+++ b/test/reload.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Home</title>
-  <script type="text/javascript" src="/js/turbolinks.js?1"></script>
+  <script type="text/javascript" src="/js/turbolinks.js?1" data-turbolinks-track='true'></script>
   <script type="text/javascript">
     document.addEventListener("page:change", function() {
       console.log("page changed");


### PR DESCRIPTION
Implemented we've discussed in #132.

Use document#reload ONLY when `data-turbolinks-track` assets are changed, otherwise use Turbolinks#visit.
