### PR TITLE
Check port separately in crossOriginLink()

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -171,7 +171,7 @@ extractLink = (event) ->
   link
 
 crossOriginLink = (link) ->
-  location.protocol isnt link.protocol or location.host isnt link.host
+  location.protocol isnt link.protocol or location.hostname isnt link.hostname or (location.port || '80') isnt (link.port || '80')
 
 anchoredLink = (link) ->
   ((link.hash and link.href.replace(link.hash, '')) is location.href.replace(location.hash, '')) or


### PR DESCRIPTION
On IE (at least) location.host doesn't include the port 
while link.host has it embedded.
