### PR TITLE
Remove hash from XHR url - Fix #142

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -17,8 +17,11 @@ visit = (url) ->
 fetchReplacement = (url) ->
   triggerEvent 'page:fetch'
 
+  # Remove hash from url to ensure IE 10 compatibility 
+  safeUrl = removeHash url
+  
   xhr = new XMLHttpRequest
-  xhr.open 'GET', removeHash(url), true
+  xhr.open 'GET', safeUrl, true
   xhr.setRequestHeader 'Accept', 'text/html, application/xhtml+xml, application/xml'
   xhr.setRequestHeader 'X-XHR-Referer', referer
 


### PR DESCRIPTION
Internet Explorer 10 is going against the W3C specification for XMLHttpRequest by not dropping the hash from the request url, causing the issue described in #142.  This commit will fix IE 10 by doing what all the other browsers do automatically.  
