### PR TITLE
Scroll to anchor link id if link has anchor tag

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -30,7 +30,10 @@ fetchReplacement = (url) ->
     else
       changePage extractTitleAndBody(doc)...
       reflectRedirectedUrl xhr
-      resetScrollPosition()
+      if document.location.hash
+        document.location.href = document.location.href
+      else
+        resetScrollPosition()
       triggerEvent 'page:load'
 
   xhr.onabort = -> console.log 'Aborted turbolink fetch!'


### PR DESCRIPTION
Fixes bug that page dose not scroll to anthor id through turbolinks.
This idea is based on
`document.locatio.href = document.location.href + '#hash_tag'`
does not make page reloading but just pageYOffset changes.
