### PR TITLE
Compatible for non rails environment.

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -87,7 +87,7 @@ reflectNewUrl = (url) ->
     window.history.pushState { turbolinks: true, position: currentState.position + 1 }, '', url
 
 reflectRedirectedUrl = (xhr) ->
-  unless (location = xhr.getResponseHeader 'X-XHR-Current-Location') is document.location.pathname + document.location.search
+  if (location = xhr.getResponseHeader 'X-XHR-Current-Location') and location isnt document.location.pathname + document.location.search
     window.history.replaceState currentState, '', location + document.location.hash
 
 rememberCurrentUrl = ->


### PR DESCRIPTION
I know turbolinks dependent on `X-XHR-Current-Location` data, but turbolinks can work in not rails environment like static website, by just requiring turbolinks.js.
This pull-req makes such compatible for non rails environment.

This is a feature request, so I want everyone's opinion.
