### PR TITLE
Fix issue when calling visit from an ajax callback outside of turbo

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -74,7 +74,8 @@ changePage = (title, body, runScripts) ->
   document.title = title
   document.documentElement.replaceChild body, document.body
   executeScriptTags() if runScripts
-  currentState = window.history.state
+  if window.history.state
+    currentState = window.history.state
   triggerEvent 'page:change'
 
 executeScriptTags = ->


### PR DESCRIPTION
When someone makes an ajax call (not a turbo'd call)
obviously they don't know to call reflectNewUrl. The effect
of this omission is that the window.history.state is null
(because nothing has been pushed to it). If the result of
that ajax call happens to call Turbolinks.visit then turbo
craps out because currentState is now null.
This patch fixes that.
