### PR TITLE
Add Turbolinks.enableScripts and .disableScripts. When disabled, scripts don't execute on executeScriptTags.

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -4,6 +4,7 @@ referer        = document.location.href
 loadedAssets   = null
 pageCache      = {}
 createDocument = null
+scriptsEnabled = true
 
 visit = (url) ->
   if browserSupportsPushState
@@ -13,6 +14,11 @@ visit = (url) ->
   else
     document.location.href = url
 
+enableScripts = ->
+  scriptsEnabled = true
+
+disableScripts = ->
+  scriptsEnabled = false
 
 fetchReplacement = (url) ->
   triggerEvent 'page:fetch'
@@ -78,13 +84,14 @@ changePage = (title, body, runScripts) ->
   triggerEvent 'page:change'
 
 executeScriptTags = ->
-  for script in document.body.getElementsByTagName 'script' when script.type in ['', 'text/javascript']
-    copy = document.createElement 'script'
-    copy.setAttribute attr.name, attr.value for attr in script.attributes
-    copy.appendChild document.createTextNode script.innerHTML
-    { parentNode, nextSibling } = script
-    parentNode.removeChild script
-    parentNode.insertBefore copy, nextSibling
+  if scriptsEnabled
+    for script in document.body.getElementsByTagName 'script' when script.type in ['', 'text/javascript']
+      copy = document.createElement 'script'
+      copy.setAttribute attr.name, attr.value for attr in script.attributes
+      copy.appendChild document.createTextNode script.innerHTML
+      { parentNode, nextSibling } = script
+      parentNode.removeChild script
+      parentNode.insertBefore copy, nextSibling
 
 
 reflectNewUrl = (url) ->
@@ -219,4 +226,4 @@ if browserSupportsPushState
     fetchHistory event.state if event.state?.turbolinks
 
 # Call Turbolinks.visit(url) from client code
-@Turbolinks = { visit }
+@Turbolinks = { visit, enableScripts, disableScripts }


### PR DESCRIPTION
When executeScriptTags runs, it can re-attach events that need not be re-attached, e.g. when using jQuery .on() at the document level.

One can entirely avoid the need to re-execute scripts by using a combination of delegated events and Turbolinks' own page: events. With this change, one only needs to call Turbolinks.disableScripts() to avoid e.g. duplicating their events with every page:change.
