### PR TITLE
disabling for chrome for iOS until resolved.

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -224,13 +224,13 @@ initializeTurbolinks = ->
 browserSupportsPushState =
   window.history and window.history.pushState and window.history.replaceState and window.history.state != undefined
 
-browserIsntCriOS =
+browserIsntBuggy =
   !navigator.userAgent.match /CriOS\//
 
 requestMethodIsSafe =
   requestMethod in ['GET','']
 
-initializeTurbolinks() if browserSupportsPushState and requestMethodIsSafe and browserIsntCriOS
+initializeTurbolinks() if browserSupportsPushState and browserIsntBuggy and requestMethodIsSafe
 
 # Call Turbolinks.visit(url) from client code
 @Turbolinks = { visit }


### PR DESCRIPTION
Temporary fix for #82 until we can better debug Chrome for iOS .. disables turbolinks if userAgent matches /CriOS\//
