### PR TITLE
Abort XHR on popstate / Maintain history when aborting XHR

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -22,13 +22,12 @@ fetchReplacement = (url) ->
   # Remove hash from url to ensure IE 10 compatibility
   safeUrl = removeHash url
 
-  xhr.abort() if xhr
+  xhr?.abort()
   xhr = new XMLHttpRequest
   xhr.open 'GET', safeUrl, true
   xhr.setRequestHeader 'Accept', 'text/html, application/xhtml+xml, application/xml'
   xhr.setRequestHeader 'X-XHR-Referer', referer
-  xhr.onabort = ->
-    xhr = null
+
   xhr.onload = =>
     doc = createDocument xhr.responseText
 
@@ -42,11 +41,10 @@ fetchReplacement = (url) ->
       else
         resetScrollPosition()
       triggerEvent 'page:load'
-    xhr = null
 
-  xhr.onerror = ->
-    document.location.href = url
-    xhr = null
+  xhr.onloadend = -> xhr = null
+  xhr.onabort   = -> rememberCurrentUrl()
+  xhr.onerror   = -> document.location.href = url
 
   xhr.send()
 
@@ -54,6 +52,7 @@ fetchHistory = (state) ->
   cacheCurrentPage()
 
   if page = pageCache[state.position]
+    xhr?.abort()
     changePage page.title, page.body
     recallScrollPosition page
     triggerEvent 'page:restore'


### PR DESCRIPTION
I was working on a fix for #155 yesterday, but @davydotcom beat me to the punch this morning.  He took almost the exact approach as I was, but his commit didn't handle a couple side effects:
1. If you clicked a link and then clicked the back button before the request finished, the page would still change to the requested page once the request finally finished.  Adding `xhr?.abort()` to `fetchHistory()` fixes this.
2. If you clicked a link and then clicked another link before the first one loaded, the first one will abort and the second requested page will load.  This is what we just fixed, but if the next thing you do is click the back button, nothing will happen.  Calling `rememberCurrentUrl()` on xhr abort ensures the proper behavior when navigating the history.  
3. I also refactored a little bit by moving all the `xhr = null` statements into the `onloadend` callback.  
