### PR TITLE
Add support for replacing tags in <head>

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ If those assets change URLs (embed an md5 stamp to ensure this), the page will d
 
 When this happens, you'll technically be requesting the same page twice. Once through Turbolinks to detect that the assets changed, and then again when we do a full redirect to that page.
 
+You can also mark any tag inside <head> with data-turbolinks-replace to replace the tag instead of doing a full page reload.
+
 
 Evaluating script tags
 ----------------------

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -35,6 +35,7 @@ fetchReplacement = (url) ->
       document.location.reload()
     else
       changePage extractTitleAndBody(doc)...
+      replaceHeadNodes doc
       reflectRedirectedUrl xhr
       if document.location.hash
         document.location.href = document.location.href
@@ -142,6 +143,13 @@ assetsChanged = (doc) ->
   loadedAssets ||= extractTrackAssets document
   fetchedAssets  = extractTrackAssets doc
   fetchedAssets.length isnt loadedAssets.length or intersection(fetchedAssets, loadedAssets).length isnt loadedAssets.length
+
+extractReplacableNodes = (head) ->
+  node for node in head.childNodes when node.getAttribute?('data-turbolinks-replace')
+
+replaceHeadNodes = (doc) ->
+  document.head.removeChild node for node in extractReplacableNodes(document.head)
+  document.head.appendChild node for node in extractReplacableNodes(doc.head)
 
 intersection = (a, b) ->
   [a, b] = [b, a] if a.length > b.length


### PR DESCRIPTION
Add ability to mark _head_ tags with data-turbolinks-replace.

This will remove the tag on page:change and replace it with the new version from the freshly fetched page.
### Example use cases:
- When session storing csrf-token might expire between page change, making the _meta_ tag invalid.
- Could be used in lieu of data-turbolinks-track to replace CSS instead of doing a full page reload.
