### PR TITLE
Handle DOMParser exception

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -167,6 +167,16 @@ browserCompatibleDocumentParser = ->
     doc.close()
     doc
 
+  # Use createDocumentUsingParser if DOMParser is defined and natively 
+  # supports 'text/html' parsing (Firefox 12+, IE 10)
+  #
+  # Use createDocumentUsingDOM if createDocumentUsingParser throws an exception
+  # due to unsupported type 'text/html' (Firefox < 12, Opera)  
+  #
+  # Use createDocumentUsingWrite if:
+  #  - DOMParser isn't defined
+  #  - createDocumentUsingParser returns null due to unsupported type 'text/html' (Chrome, Safari)
+  #  - createDocumentUsingDOM doesn't create a valid HTML document (safeguarding against potential edge cases)
   try
     if window.DOMParser
       testDoc = createDocumentUsingParser '<html><body><p>test'


### PR DESCRIPTION
- Fixes #168
- Alternative to #174
- Implemented without overloading **DOMParser**
- Tested on:
  - Firefox 9
  - Firefox 18.0.1
  - Opera 12.12
  - Chrome 24.0.1312.56
  - Safari 6.0
