### PR TITLE
Remove <noscript> tags - Fixes #176

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -79,6 +79,7 @@ constrainPageCacheTo = (limit) ->
 changePage = (title, body, runScripts) ->
   document.title = title
   document.documentElement.replaceChild body, document.body
+  removeNoscriptTags()
   executeScriptTags() if runScripts
   currentState = window.history.state
   triggerEvent 'page:change'
@@ -92,6 +93,8 @@ executeScriptTags = ->
     parentNode.removeChild script
     parentNode.insertBefore copy, nextSibling
 
+removeNoscriptTags = ->
+  noscript.parentNode.removeChild noscript for noscript in document.body.getElementsByTagName 'noscript'
 
 reflectNewUrl = (url) ->
   if url isnt document.location.href


### PR DESCRIPTION
After changing the page, remove all `<noscript>` tags from the body.  Prevents issue described in #176.  
