### PR TITLE
Add link to compatibility project

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Compatibility
 
 Turbolinks is designed to work with any browser that fully supports pushState and all the related APIs. This includes Safari 6.0+ (but not Safari 5.1.x!), IE10, and latest Chromes and Firefoxes.
 
-Do note that existing JavaScript libraries may not all be compatible with Turbolinks out of the box due to the change in instantiation cycle. You might very well have to modify them to work with Turbolinks' new set of events.
+Do note that existing JavaScript libraries may not all be compatible with Turbolinks out of the box due to the change in instantiation cycle. You might very well have to modify them to work with Turbolinks' new set of events.  For help with this, check out the [Turbolinks Compatibility](http://reednj77.github.com/turbolinks-compatibility) project.
 
 
 Installation


### PR DESCRIPTION
@dhh I know you asked me to make a compatibility file, but I thought doing that would introduce a slew of pull requests and issues that aren't relevant to Turbolinks itself.  I figured it'd be better off as it's own project, so I built this Github Pages site:

http://reednj77.github.com/turbolinks-compatibility

I'm open to suggestions for improvements.

This PR just adds a link to it in the readme.  
