### PR TITLE
Reflect X-XHR-Referer in request.referer - closes #169

### DIFF
--- a/lib/turbolinks.rb
+++ b/lib/turbolinks.rb
@@ -33,6 +33,13 @@ module Turbolinks
         include XHRHeaders, Cookies
         before_filter :set_xhr_current_location, :set_request_method_cookie
       end
+      
+      ActionDispatch::Request.class_eval do
+        def referer
+          self.headers['X-XHR-Referer'] || super
+        end
+        alias referrer referer
+      end
     end
   end
 end


### PR DESCRIPTION
This is an implementation of the idea proposed in #169.  It ensures that `request.referer` returns the expected url.  

The existing `referer` method is defined on Rack::Request:

``` ruby
module Rack
  class Request
    def referer
      @env['HTTP_REFERER']
    end
    alias referrer referer
  end
end
```

This patch defines a `referer` method on ActionDispatch::Request that will return the value of the `X-XHR-Referer` request header if it exists and falls back to the original method if it doesn't:

``` ruby
module ActionDispatch
  class Request < Rack::Request
    def referer
      self.headers['X-XHR-Referer'] || super
    end
    alias referrer referer
  end
end
```
