### PR TITLE
copy noscript tag list by slicing so that removeNoscriptTags works with multiple noscript tags

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -94,7 +94,8 @@ executeScriptTags = ->
     parentNode.insertBefore copy, nextSibling
 
 removeNoscriptTags = ->
-  noscript.parentNode.removeChild noscript for noscript in document.body.getElementsByTagName 'noscript'
+  noscriptTags = Array::slice.call document.body.getElementsByTagName 'noscript'
+  noscript.parentNode.removeChild noscript for noscript in noscriptTags
 
 reflectNewUrl = (url) ->
   if url isnt document.location.href


### PR DESCRIPTION
in google chrome 24.0.1312.57 the tag list changes while we iterate over it and delete tags.
in order to make this function work with multiple no script tags we have to copy the original tag list.
