### PR TITLE
Copy script tag list by slicing

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -85,7 +85,8 @@ changePage = (title, body, runScripts) ->
   triggerEvent 'page:change'
 
 executeScriptTags = ->
-  for script in document.body.getElementsByTagName 'script' when script.type in ['', 'text/javascript']
+  scripts = Array::slice.call document.body.getElementsByTagName 'script'
+  for script in scripts when script.type in ['', 'text/javascript']
     copy = document.createElement 'script'
     copy.setAttribute attr.name, attr.value for attr in script.attributes
     copy.appendChild document.createTextNode script.innerHTML


### PR DESCRIPTION
Same issue as #186 but for executeScriptTags.  Didn't originally think this was necessary since the number of scripts on the page isn't directly changed by each iteration of the loop, but I ran into a scenario where it's indirectly changed:

``` html
<body>
   <div id="container">
      <script>
      $('#container').html("content");
      </script>
   </div>
   <script>
   // another script
   </script>
</body>
```

If there are multiple scripts on the page and any of them except the last one remove or overwrite themselves, executeScriptTags will throw an error.
