### PR TITLE
Add a page:received event.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Since pages will change without a full reload with Turbolinks, you can't by defa
 * `page:load`    fetched page is being retrieved fresh from the server.
 * `page:restore` fetched page is being retrieved from the 10-slot client-side cache.
 * `page:change`  page has changed to the newly fetched version.
+* `page:receive` page has been fetched from the server, but not yet parsed.
 
 So if you wanted to have a client-side spinner, you could listen for `page:fetch` to start it and `page:change` to stop it. If you have DOM transformation that are not idempotent (the best way), you can hook them to happen only on `page:load` instead of `page:change` (as that would run them again on the cached pages).
 

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -29,7 +29,7 @@ fetchReplacement = (url) ->
   xhr.setRequestHeader 'X-XHR-Referer', referer
 
   xhr.onload = =>
-    triggerEvent 'page:received'
+    triggerEvent 'page:receive'
     doc = createDocument xhr.responseText
 
     if assetsChanged doc


### PR DESCRIPTION
For a page load that is not from the Turbolinks cache, this event
callback is triggered after page:fetch but before page:change,
specifically as soon as the XHR response body is available (in the
XHR onload handler).

Having an instrumentation point as early as possible once a response is received
from the server allows for a more accurate measurement of network vs. frontend
time when Turbolinks is enabled. This is important for performance-monitoring
tools like New Relic (which, full disclosure: I work there).

Note: it might also be useful to attach the actual XHR object to this event, in
order to allow client code to inspect and/or modify it before it's seen by the
rest of the Turbolinks code, but lacking a concrete use case, I opted to skip
that for now and keep this as minimal as possible.
