### PR TITLE
Maintain CSRF authenticity token - Fixes #171

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -76,9 +76,10 @@ constrainPageCacheTo = (limit) ->
   for own key, value of pageCache
     pageCache[key] = null if key <= currentState.position - limit
 
-changePage = (title, body, runScripts) ->
+changePage = (title, body, csrfToken, runScripts) ->
   document.title = title
   document.documentElement.replaceChild body, document.body
+  CSRFToken.update csrfToken if csrfToken?
   removeNoscriptTags()
   executeScriptTags() if runScripts
   currentState = window.history.state
@@ -157,8 +158,18 @@ intersection = (a, b) ->
 
 extractTitleAndBody = (doc) ->
   title = doc.querySelector 'title'
-  [ title?.textContent, doc.body, 'runScripts' ]
+  [ title?.textContent, doc.body, CSRFToken.get(doc).token, 'runScripts' ]
 
+CSRFToken =
+  get: (doc = document) ->
+    node:   tag = doc.querySelector 'meta[name="csrf-token"]'
+    token:  tag?.getAttribute? 'content'
+    
+  update: (latest) ->
+    current = @get()
+    if current.token? and latest? and current.token isnt latest
+      current.node.setAttribute 'content', latest
+      
 browserCompatibleDocumentParser = ->
   createDocumentUsingParser = (html) ->
     (new DOMParser).parseFromString html, 'text/html'


### PR DESCRIPTION
This is a more focused solution that what was proposed #165, internally keeping the CSRF token current (if it exists) instead of requiring the developer to add a data attribute.  

My reasoning behind wanting to implement this is the fact that the **jquery_ujs** driver explicitly reads from the csrf-token meta tag and uses it when setting the `X-CSRF-Token` request header and also in a hidden field of the form that's created and submitted when a link with `data-method` defined is clicked.  This is the underlying cause of the use case described in #171, and keeping the meta tag up-to-date would resolve it.  

Looking for some feedback on this.

/cc @satb @macournoyer @dhh 
