### PR TITLE
avoid creating unused results arrays

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -75,7 +75,7 @@ cacheCurrentPage = ->
 constrainPageCacheTo = (limit) ->
   for own key, value of pageCache
     pageCache[key] = null if key <= currentState.position - limit
-  undefined
+  return
 
 changePage = (title, body, runScripts) ->
   document.title = title
@@ -94,12 +94,12 @@ executeScriptTags = ->
     { parentNode, nextSibling } = script
     parentNode.removeChild script
     parentNode.insertBefore copy, nextSibling
-  undefined
+  return
 
 removeNoscriptTags = ->
   noscriptTags = Array::slice.call document.body.getElementsByTagName 'noscript'
   noscript.parentNode.removeChild noscript for noscript in noscriptTags
-  undefined
+  return
 
 reflectNewUrl = (url) ->
   if url isnt document.location.href


### PR DESCRIPTION
These functions are returning the results of their for comprehensions unnecessarily. Returning `undefined` ensures coffee doesn't store the results of the comprehensions, which is faster and less GC/memory intensive.
