### PR TITLE
Clone document.body to avoid tampering with cached pages

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -65,7 +65,7 @@ cacheCurrentPage = ->
 
   pageCache[currentState.position] =
     url:       document.location.href,
-    body:      document.body,
+    body:      document.body.cloneNode(true),
     title:     document.title,
     positionY: window.pageYOffset,
     positionX: window.pageXOffset


### PR DESCRIPTION
I think the current caching implementation is faulty, shouldn't `cacheCurrentPage` store a clone of the `document.body` rather than a reference? 

Otherwise it's possible to accidentally tamper with the cached page. I ran into this problem when removing Backbone.Views on `page:change`. Turbolinks was caching the page with the views removed, as the remove was acting on the live `document.body`.
