### PR TITLE
Add option to not re-evaluate specific script tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Turbolinks (master) ##
 
+*   Add the ability to not execute scripts on turbolinks page loads by
+    specifying `data-turbolinks-eval=false` on the `<script>` tag. For example:
+    `<script type="text/javascript" data-turbolinks-eval=false>`
+
+    *Mario Visic*
+
 *   Workaround for WebKit history state [bug](https://bugs.webkit.org/show_bug.cgi?id=93506) 
     with regards to the handling of 4xx responses.
     

--- a/README.md
+++ b/README.md
@@ -104,7 +104,13 @@ Evaluating script tags
 
 Turbolinks will evaluate any script tags in pages it visit, if those tags do not have a type or if the type is text/javascript. All other script tags will be ignored.
 
-As a rule of thumb when switching to Turbolinks, move all of your javascript tags inside the `head` and then work backwards, only moving javascript code back to the body if absolutely necessary.
+As a rule of thumb when switching to Turbolinks, move all of your javascript tags inside the `head` and then work backwards, only moving javascript code back to the body if absolutely necessary. If you have any script tags in the body you do not want to be re-evaluated then you can set the `data-turbolinks-eval` attribute to `false`:
+
+```html
+<script type="text/javascript" data-turbolinks-eval=false>
+  console.log("I'm only run once on the initial page load");
+</script>
+```
 
 Triggering a Turbolinks visit manually
 ---------------------------------------

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -85,7 +85,7 @@ changePage = (title, body, csrfToken, runScripts) ->
   triggerEvent 'page:change'
 
 executeScriptTags = ->
-  scripts = Array::slice.call document.body.getElementsByTagName 'script'
+  scripts = Array::slice.call document.body.querySelectorAll 'script:not([data-turbolinks-eval="false"])'
   for script in scripts when script.type in ['', 'text/javascript']
     copy = document.createElement 'script'
     copy.setAttribute attr.name, attr.value for attr in script.attributes

--- a/test/index.html
+++ b/test/index.html
@@ -28,5 +28,9 @@
   <div style="background:#ccc;height:5000px;width:200px;">
   </div>
   <iframe height='1' scrolling='no' src='/offline.html' style='display: none;' width='1'></iframe>
+
+  <script type="text/javascript" data-turbolinks-eval=false>
+    console.log("turbolinks-eval-false script fired. This should only happen on the initial page load.");
+  </script>
 </body>
 </html>


### PR DESCRIPTION
Adding `data-turbolinks-eval=false` to a script tag will not re-evaluate the JavaScript again on turbolinks page visits.  This can be used to avoid moving script tags to the `<head>` to improve uncached page load times.
