### PR TITLE
Preserve trailing slash in URL path - Fixes #218

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 
     *Nick Reed*
 
+*   If present, preserve trailing slash in URL path.
+
+    *Nick Reed*
+
 ## Turbolinks 1.1.1 (April 3, 2013) ##
 
 *   Improve performance of `constrainPageCacheTo`, `executeScriptTags`, and `removeNoscriptTags`

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -106,7 +106,8 @@ reflectNewUrl = (url) ->
     window.history.pushState { turbolinks: true, position: currentState.position + 1 }, '', url
 
 reflectRedirectedUrl = ->
-  if (location = xhr.getResponseHeader 'X-XHR-Current-Location') and location isnt document.location.pathname + document.location.search
+  location = xhr.getResponseHeader 'X-XHR-Current-Location'
+  if location and location isnt normalizePath(document.location.pathname) + document.location.search
     window.history.replaceState currentState, '', location + document.location.hash
 
 rememberCurrentUrl = ->
@@ -134,6 +135,14 @@ removeHash = (url) ->
     link = document.createElement 'A'
     link.href = url
   link.href.replace link.hash, ''
+
+# Strips off trailing slash and ensures there is a leading slash
+normalizePath = (path) ->
+  path = "/#{path}"
+  path = path.replace /\/+/g, '/'
+  path = path.replace /\/+$/, ''
+  path = '/' if path is ''
+  path
 
 
 triggerEvent = (name) ->


### PR DESCRIPTION
Fixes the issue described in #218.

The URI string that gets saved to the `X-XHR-Current-Location` header has been run through the **ActionDispatch::Journey::Router::Utils.normalize_path()** filter, which strips the trailing slash.  This commit implements that filter on the client side (on document.location.pathname) so we can accurately check to see if the request was redirected.  As a result, clicking a link to `/path/` no longer leads to the URL being changed to `/path`.
