### PR TITLE
Update 'page:changed' to 'page:change' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ With Turbolinks pages will change without a full reload, so you can't rely on `D
 *Load* a fresh version of a page from the server:
 * `page:fetch` starting to fetch a new target page
 * `page:receive` the page has been fetched from the server, but not yet parsed
-* `page:changed` the page has been parsed and changed to the new version
+* `page:change` the page has been parsed and changed to the new version
 * `page:load` is fired at the end of the loading process.
 
 Turbolinks caches 10 of these page loads. It listens to the [popstate](https://developer.mozilla.org/en-US/docs/DOM/Manipulating_the_browser_history#The_popstate_event) event and attempts restore page state from the cache when it's triggered. When `popstate` is fired the following process happens:
 
 *Restore* a cached page from the client-side cache:
-* `page:changed` page has changed to the cached page.
+* `page:change` page has changed to the cached page.
 * `page:restore` is fired at the end of restore process.
 
 So if you wanted to have a client-side spinner, you could listen for `page:fetch` to start it and `page:receive` to stop it.


### PR DESCRIPTION
The README mentions the "page:changed" event, which is really called "page:change". This fixes the typo.
