### PR TITLE
handle server 5xx errors and improve readability and perf

### DIFF
--- a/test/config.ru
+++ b/test/config.ru
@@ -11,4 +11,10 @@ map "/js" do
   run Assets
 end
 
-run Rack::Directory.new(File.join(Root, "test"))
+map "/500" do
+  # throw 500 internal server error
+end
+
+map "/" do
+  run Rack::Directory.new(File.join(Root, "test"))
+end

--- a/test/index.html
+++ b/test/index.html
@@ -22,6 +22,7 @@
     <li><a href="/reload.html#foo">New assets track with hash link</a></li>
     <li><h5>If you stop the server or go into airplane/offline mode</h5></li>
     <li><a href="/doesnotexist.html">A page that errors should error out</a></li>
+    <li><a href="/500">Internal Server Error</a></li>
     <li><a href="/fallback.html">A page that has a fallback in appcache should fallback</a></li>
   </ul>
 


### PR DESCRIPTION
Server errors should be processed like client errors, (aka reload page) and this PR fixes that.

This PR also contain small changes related to readability and performance, which I made during debuging this issue (with correct undo - redo browser buttons support)

marek
