### PR TITLE
Verifying state in Turbolinks.visit

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -8,7 +8,7 @@ requestMethod  = document.cookie.match(/request_method=(\w+)/)?[1].toUpperCase()
 xhr            = null
 
 visit = (url) ->
-  if browserSupportsPushState && browserIsntBuggy
+  if browserSupportsPushState && browserIsntBuggy && stateIsntBuggy
     cacheCurrentPage()
     reflectNewUrl url
     fetchReplacement url
@@ -281,6 +281,9 @@ browserSupportsPushState =
 
 browserIsntBuggy =
   !navigator.userAgent.match /CriOS\//
+
+stateIsntBuggy =
+  window.history.state isnt null
 
 requestMethodIsSafe =
   requestMethod in ['GET','']


### PR DESCRIPTION
More than once, after visiting lots of URLs with Turbolinks.visit,
most of times changing the location.search, the window.history.state
became null for some reason.

This PR commit contains a very silly workaround for it, since I can't find any other solution.

The issue is similar as the described [here](https://github.com/rails/turbolinks/pull/199#issuecomment-19731190).

I could reproduce it in Chrome 27 in OSX.
