### PR TITLE
Preventing fetchReplacement when page has history in Chrome.

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -273,7 +273,11 @@ ignoreClick = (event, link) ->
 initializeTurbolinks = ->
   document.addEventListener 'click', installClickHandlerLast, true
   window.addEventListener 'popstate', (event) ->
-    fetchHistory event.state if event.state?.turbolinks
+    if event.state?.turbolinks
+      if initialized
+        fetchHistory event.state
+      else
+        cacheCurrentPage()
   , false
 
 browserSupportsPushState =


### PR DESCRIPTION
Fix for https://github.com/rails/turbolinks/issues/236
