### PR TITLE
Update README.md to fix overflowing code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@ Asset change detection
 
 You can track certain assets, like application.js and application.css, that you want to ensure are always of the latest version inside a Turbolinks session. This is done by marking those asset links with data-turbolinks-track, like so:
 
-```<link href="/assets/application-9bd64a86adb3cd9ab3b16e9dca67a33a.css" rel="stylesheet" type="text/css" data-turbolinks-track>```
+```html
+<link href="/assets/application-9bd64a86adb3cd9ab3b16e9dca67a33a.css" rel="stylesheet"
+      type="text/css" data-turbolinks-track>
+```
 
 If those assets change URLs (embed an md5 stamp to ensure this), the page will do a full reload instead of going through Turbolinks. This ensures that all Turbolinks sessions will always be running off your latest JavaScript and CSS.
 


### PR DESCRIPTION
The "Asset change detection" code snippet overflowed from the 
content area, so I added a newline in the middle of it and made
it be a code block.
