### PR TITLE
Add link to Wiselinks to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Turbolinks
 
 Turbolinks makes following links in your web application faster. Instead of letting the browser recompile the JavaScript and CSS between each page change, it keeps the current page instance alive and replaces only the body and the title in the head. Think CGI vs persistent process.
 
-This is similar to [pjax](https://github.com/defunkt/jquery-pjax), but instead of worrying about what element on the page to replace, and tailoring the server-side response to fit, we replace the entire body. This means that you get the bulk of the speed benefits from pjax (no recompiling of the JavaScript or CSS) without having to tailor the server-side response. It just works.
+This is similar to [pjax](https://github.com/defunkt/jquery-pjax) or [wiselinks](https://github.com/igor-alexandrov/wiselinks), but instead of worrying about what element on the page to replace, and tailoring the server-side response to fit, we replace the entire body. This means that you get the bulk of the speed benefits from pjax (no recompiling of the JavaScript or CSS) without having to tailor the server-side response. It just works.
 
 Do note that this of course means that you'll have a long-running, persistent session with maintained state. That's what's making it so fast. But it also means that you may have to pay additional care not to leak memory or otherwise bloat that long-running state. That should rarely be a problem unless you're doing something really funky, but you do have to be aware of it. Your memory leaking sins will not be swept away automatically by the cleansing page change any more.
 
@@ -45,7 +45,7 @@ So if you wanted to have a client-side spinner, you could listen for `page:fetch
 
     document.addEventListener("page:fetch", startSpinner);
     document.addEventListener("page:receive", stopSpinner);
-    
+
 DOM transformations that are idempotent are best. If you have transformations that are not, hook them to happen only on `page:load` instead of `page:change` (as that would run them again on the cached pages).
 
 Initialization


### PR DESCRIPTION
Hello,
Wiselinks is another popular solution for browser history and state management, so I decided that Turbolinks should have a link to it in README file (like it has link to PJAX).
