### PR TITLE
Transition Cache: Decrease time to page change by displaying a cached copy temporarily

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -74,7 +74,7 @@ latestPageCacheFromUrl = (url) ->
   pageCacheKeysLatestFirst = Object.keys(pageCache).sort (a, b) -> b - a
 
   isCacheForUrl = (cache, url) ->
-    cache and cache.url is url and !cache.prefetchCacheDisabled
+    cache?.url is url and !cache.prefetchCacheDisabled
 
   for key in pageCacheKeysLatestFirst
     return pageCache[key] if isCacheForUrl(pageCache[key], url)


### PR DESCRIPTION
If a link is clicked and we have a cached copy of the destination available (in `pageCache`), then display the cached page before fetching the replacement. This makes clicking between links of cached pages feel instantaneous.

This is similar to a wonderful technique Basecamp uses to display cached "sheets" quickly. The Turbolinks cache is limited to the last 10 pages visited (not sure why?) but that's ok—this feature is tailor made for people who are navigating to and from pages.
