### PR TITLE
 Add `page:fetch` and `page:receive` events to fetchHistory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@
 *   Expire `request_method` cookie after reading it.
 
     *Nick Reed*
-    
+
+*   Trigger `page:fetch` and `page:receive` events also when we fetch page from history.
+
+    *Marek Labos*
+
 ## Turbolinks 1.3.0 (July 11, 2013) ##
 
 *   Change URL *after* fetching page.

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -9,7 +9,7 @@ createDocument = null
 xhr            = null
 
 
-fetchReplacement = (url) ->  
+fetchReplacement = (url) ->
   rememberReferer()
   cacheCurrentPage()
   triggerEvent 'page:fetch', url: url
@@ -40,7 +40,9 @@ fetchReplacement = (url) ->
 
 fetchHistory = (cachedPage) ->
   cacheCurrentPage()
+  triggerEvent 'page:fetch', url: cachedPage.url
   xhr?.abort()
+  triggerEvent 'page:receive'
   changePage cachedPage.title, cachedPage.body
   recallScrollPosition cachedPage
   triggerEvent 'page:restore'


### PR DESCRIPTION
I think there is no difference if we fetch page from server or history, especially when we want do something before is page changed.
Event 'page:restore' is not enough because after page is changed some references may been broken (personal experience).
