### PR TITLE
Get rid of url attribute in pageCache

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -48,7 +48,6 @@ fetchHistory = (cachedPage) ->
 
 cacheCurrentPage = ->
   pageCache[currentState.position] =
-    url:       document.location.href,
     body:      document.body,
     title:     document.title,
     positionY: window.pageYOffset,


### PR DESCRIPTION
Found this while digging through code. Might save a future contributor time if they think the `url` option can be used.
