### PR TITLE
Fix exceptions with jQuery.noConflict()

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -272,8 +272,8 @@ installDocumentReadyPageEventTriggers = ->
 
 installJqueryAjaxSuccessPageUpdateTrigger = ->
   if typeof jQuery isnt 'undefined'
-    $(document).on 'ajaxSuccess', (event, xhr, settings) ->
-      return unless $.trim xhr.responseText
+    jQuery(document).on 'ajaxSuccess', (event, xhr, settings) ->
+      return unless jQuery.trim xhr.responseText
       triggerEvent 'page:update'
 
 installHistoryChangeHandler = (event) ->


### PR DESCRIPTION
When using `Turbolinks` with `jQuery` and other libraries that depend on the `$` function/object there are exceptions due to jQuery not being aliased to `$`.

One solution might be putting the

``` js
jQuery.noConflict();
```

call right after loading `turbolinks` in the `application.js` manifest, but it's a bit arcane and unclean.
