### PR TITLE
Fixed issue where extracted assets may or may not include the host in th...

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -151,7 +151,7 @@ processResponse = ->
     xhr.getResponseHeader('Content-Type').match /^(?:text\/html|application\/xhtml\+xml|application\/xml)(?:;|$)/
 
   extractTrackAssets = (doc) ->
-    (node.src || node.href) for node in doc.head.childNodes when node.getAttribute?('data-turbolinks-track')?
+    (node.getAttribute('src') || node.getAttribute('href')) for node in doc.head.childNodes when node.getAttribute?('data-turbolinks-track')?
 
   assetsChanged = (doc) ->
     loadedAssets ||= extractTrackAssets document


### PR DESCRIPTION
I found that turbolinks didn't work on Mac Safari WebKit Nightly 8536.30.1, 538+. This was because the `extractTrackAssets()` function was using `node.src` and `node.href`, which returned either the full-URL complete with scheme and host or the path only, depending on whether we were looking at the current document or the doc created from the AJAX response. (i.e. "http://localhost:3000/assets/jquery.js" or "/assets/jquery.js") This causes `assetsChanged()` to always evaluate to true, even when the assets haven't really changed.

Using `node.getAttribute('src')` and `node.getAttribute('href')` instead of `node.src` and `node.href` ensures that  `extractTrackAssets()` will return strings exactly as they are in the HTML source, and make the  `assetsChanged()` more robust.
