### PR TITLE
Make Turbolinks not throw javascript exceptions on IE < 9

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -272,7 +272,7 @@ installDocumentReadyPageEventTriggers = ->
   if document.addEventListener?
     document.addEventListener 'DOMContentLoaded', triggerDocumentReadyPageEvents, true
   else if document.attachEvent?
-    document.attachEvent 'DOMContentLoaded', triggerDocumentReadyPageEvents
+    document.attachEvent 'onreadystatechange', triggerDocumentReadyPageEvents
 
 installJqueryAjaxSuccessPageUpdateTrigger = ->
   if typeof jQuery isnt 'undefined'


### PR DESCRIPTION
Turbolinks does not gracefully degrade to non-ajax behavior on IE < 9. Instead, it triggers javascript exceptions.

The exceptions happen because event handlers are installed via document.addEventListener() even when the browser doesn't support Turbolinks. Calling document.addEventListener() on IE8 triggers an exception.

Seemed to me the simplest fix was to only call installDocumentReadyPageEventTriggers() and installJqueryAjaxSuccessPageUpdateTrigger() if Turbolinks is supported.
