### PR TITLE
Fixes Uncaught SecurityError when trying to replace history state with an URL from a different Origin

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -97,7 +97,9 @@ reflectNewUrl = (url) ->
 reflectRedirectedUrl = ->
   if location = xhr.getResponseHeader 'X-XHR-Redirected-To'
     preservedHash = if removeHash(location) is location then document.location.hash else ''
-    window.history.replaceState currentState, '', location + preservedHash
+    host = new RegExp(window.location.host)
+    if location.match(host)
+      window.history.replaceState currentState, '', location + preservedHash
 
 rememberReferer = ->
   referer = document.location.href


### PR DESCRIPTION
Chrome throws this error when using a redirect to point an image source to an external URL : 
`Uncaught SecurityError: A history state object with URL 'http://www.placecage.com/300/400' cannot be created in a document with origin 'http://localhost:3000'.`

This skips the redirect URL history replace behaviour in these cases.
