### PR TITLE
jQuery should be required before turbolinks in manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Installation
 
 1. Add `gem 'turbolinks'` to your Gemfile.
 1. Run `bundle install`.
-1. Add `//= require turbolinks` to your Javascript manifest file (usually found at `app/assets/javascripts/application.js`).
+1. Add `//= require turbolinks` to your Javascript manifest file (usually found at `app/assets/javascripts/application.js`). If your manifest requires both turbolinks and jQuery, make sure turbolinks is listed *after* jQuery.
 1. Restart your server and you're now using turbolinks!
 
 Language Ports


### PR DESCRIPTION
Turbolinks documentation states that `page:update` is triggered on jQuery's `ajaxSuccess` event, but this feature only works if jQuery is loaded  before turbolinks. Make this load order requirement clear in the installation instructions.
