### PR TITLE
Note that transition cache is currently available only on master

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ DOM transformations that are idempotent are best. If you have transformations th
 Transition Cache: A Speed Boost
 -------------------------------------
 
+**Note: Transition cache is only available on master. To enable the feature, you must point the turbolinks gem to master: `gem "turbolinks", github: "rails/turbolinks"`**
+
 Transition Cache is an experimental feature that makes loading cached pages instanteneous. Once a user has visited a page, returning later to the page results in an instant load.
 
 For example, if Page A is already cached by Turbolinks and you are on Page B, clicking a link to Page A will *immediately* display the cached copy of Page A. Turbolinks will then fetch Page A from the server and replace the cached page once the new copy is returned.


### PR DESCRIPTION
@nicka reported via https://github.com/rails/turbolinks/issues/327 that he tried using `Turbolinks.enableTransitionCache` but got a no method error. This is because he was running 2.1.0, which does not include transition cache.

I added this note to make it clear to point the turbolinks gem to master. Maybe it's worthwhile to bump to 2.1.1 to make transition cache a bit easier to use?
