### PR TITLE
Forms behave wrong on history back

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -11,6 +11,7 @@ referer                 = null
 createDocument          = null
 xhr                     = null
 
+ignoreInitalRequest = true
 
 fetch = (url) ->
   rememberReferer()
@@ -307,8 +308,9 @@ installHistoryChangeHandler = (event) ->
     if cachedPage = pageCache[event.state.url]
       cacheCurrentPage()
       fetchHistory cachedPage
-    else
+    else if ! ignoreInitalRequest
       visit event.target.location.href
+  ignoreInitalRequest = false
 
 initializeTurbolinks = ->
   rememberCurrentUrl()


### PR DESCRIPTION
The Problem right now is that `window.addEventListener 'popstate'` fires immediately after it is set, if the user goes back in history, I don't see a reason for this to happen. Most of the time you don't notice it, the same page gets loaded twice (second time from cache), (that's bad, because some unnecessary code gets executed), but the user doesn't notice it. While working with forms its different, when the user submits a form and goes back in browser history, he should see the stuff he entered/changed in the form, instead Turbolikes loads the inital page from cache and replaces it. User sees the form like he found it when he was starting to work on it. In some cases this is more then a terrible user experience. Please please explain me why this stuff needs to happen or fix it :)
