### PR TITLE
Always use the absolute URL when caching a page and looking up a cached page

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -17,7 +17,7 @@ fetch = (url) ->
   cacheCurrentPage()
   reflectNewUrl url
 
-  if transitionCacheEnabled and cachedPage = transitionCacheFor(document.location.href)
+  if transitionCacheEnabled and cachedPage = transitionCacheFor(absoluteUrl(url))
     fetchHistory cachedPage
     fetchReplacement url
   else
@@ -63,7 +63,7 @@ fetchHistory = (cachedPage) ->
 
 
 cacheCurrentPage = ->
-  pageCache[document.location.href] =
+  pageCache[absoluteUrl(currentState.url)] =
     url:                      document.location.href,
     body:                     document.body,
     title:                    document.title,
@@ -139,6 +139,9 @@ resetScrollPosition = ->
   else
     window.scrollTo 0, 0
 
+absoluteUrl = (url) ->
+  (link = document.createElement 'a').href = url
+  link.href
 
 # Intention revealing function alias
 removeHashForIE10compatiblity = (url) ->

--- a/turbolinks.gemspec
+++ b/turbolinks.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name     = 'turbolinks'
-  s.version  = '2.2.0'
+  s.version  = '2.2.1'
   s.author   = 'David Heinemeier Hansson'
   s.email    = 'david@loudthinking.com'
   s.license  = 'MIT'


### PR DESCRIPTION
This avoids having two versions of a page cached, one with a relative URL and one with an absolute URL. 

I have been experimenting with this on aha.io and it fixes issue #333. I don't know the Turbolinks code well enough to know if there are other implications of this change. 
