### PR TITLE
[Alternative Solution] Always use absolute URLs for cache keys and in state objects - Fixes #333 Closes #334

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Turbolinks (master)
+
+*   Always use absolute URLs as cache keys and in state objects.  Eliminates possibility of multiple 
+    cache objects for the same page. 
+
+    *Nick Reed*
+
 ## Turbolinks 2.2.1 (January 30, 2014)
 
 *   Do not store redirect_to location in session if the request did not come from Turbolinks.  Fixes


### PR DESCRIPTION
@k1w1 Your fix (#334) has the right idea, but it won't work when traversing the browser history.  When you hit the back button and `cacheCurrentPage` is called, `document.location.href` has already changed to the new URL.  So you'll end up with a page cached with the wrong key.  Try out my solution and let me know if it works for you.  

@dhh I also did a bit of refactoring to clean up and organize the code.  Does it look good to you?
