### PR TITLE
Allow url_for to still be called with no parameters

### DIFF
--- a/lib/turbolinks/xhr_url_for.rb
+++ b/lib/turbolinks/xhr_url_for.rb
@@ -7,7 +7,7 @@ module Turbolinks
       base.alias_method_chain :url_for, :xhr_referer
     end
  
-    def url_for_with_xhr_referer(options)
+    def url_for_with_xhr_referer(options = {})
       options = (xhr_referer || options) if options == :back
       url_for_without_xhr_referer options
     end


### PR DESCRIPTION
Allow url_for to still be called with no parameters, just like the one we're overriding.
