### PR TITLE
Use AS.on_load in the initializer

### DIFF
--- a/lib/turbolinks.rb
+++ b/lib/turbolinks.rb
@@ -8,21 +8,27 @@ require 'turbolinks/redirection'
 module Turbolinks
   class Engine < ::Rails::Engine
     initializer :turbolinks do |config|
-      ActionController::Base.class_eval do
-        include XHRHeaders, Cookies, XDomainBlocker, Redirection
-        before_filter :set_xhr_redirected_to, :set_request_method_cookie
-        after_filter :abort_xdomain_redirect
-      end
-
-      ActionDispatch::Request.class_eval do
-        def referer
-          self.headers['X-XHR-Referer'] || super
+      ActiveSupport.on_load(:action_controller) do
+        ActionController::Base.class_eval do
+          include XHRHeaders, Cookies, XDomainBlocker, Redirection
+          before_filter :set_xhr_redirected_to, :set_request_method_cookie
+          after_filter :abort_xdomain_redirect
         end
-        alias referrer referer
       end
 
-      (ActionView::RoutingUrlFor rescue ActionView::Helpers::UrlHelper).module_eval do
-        include XHRUrlFor
+      ActiveSupport.on_load(:action_dispatch) do
+        ActionDispatch::Request.class_eval do
+          def referer
+            self.headers['X-XHR-Referer'] || super
+          end
+          alias referrer referer
+        end
+      end
+
+      ActiveSupport.on_load(:action_view) do
+        (ActionView::RoutingUrlFor rescue ActionView::Helpers::UrlHelper).module_eval do
+          include XHRUrlFor
+        end
       end
     end
   end


### PR DESCRIPTION
Without these hooks, `require 'turbolinks'` (usually via bundler) immediately triggers ActionController, ActionDispatch, and ActionView initializers.
