### PR TITLE
fixed _nonHtml to work on pathname only (without query string), added test

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -289,8 +289,7 @@ class Link extends ComponentUrl
       (@href is current.href + '#') 
 
   _nonHtml: ->
-    url = @withoutHash()
-    url.match(/\.[a-z]+(\?.*)?$/g) and not url.match(new RegExp("\\.(?:#{Link.HTML_EXTENSIONS.join('|')})?(\\?.*)?$", 'g'))
+    @pathname.match(/\.[a-z]+$/g) and not @pathname.match(new RegExp("\\.(?:#{Link.HTML_EXTENSIONS.join('|')})?$", 'g'))
 
   _optOut: ->
     link = @link

--- a/test/config.ru
+++ b/test/config.ru
@@ -15,6 +15,10 @@ map "/500" do
   # throw Internal Server Error (500)
 end
 
+map "/withoutextension" do
+  run Rack::File.new(File.join(Root, "test", "withoutextension"), "Content-Type" => "text/html")
+end
+
 map "/" do
   run Rack::Directory.new(File.join(Root, "test"))
 end

--- a/test/index.html
+++ b/test/index.html
@@ -22,6 +22,8 @@
   <ul style="margin-top:200px;">
     <li><a href="/other.html">Other page</a></li>
     <li><a href="/other.html"><span>Wrapped link</span></a></li>
+    <li><a href="/withoutextension">Without extension</a></li>
+    <li><a href="/withoutextension?sort=user.name">Without extension with query params</a></li>
     <li><a href="http://www.google.com/">Cross origin</a></li>
     <li><a href="/other.html" onclick="if(!confirm('follow link?')) { return false}">Confirm Fire Order</a></li>
     <li><a href="/reload.html"><span>New assets track </span></a></li>

--- a/test/withoutextension
+++ b/test/withoutextension
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Home</title>
+  <script type="text/javascript" src="/js/turbolinks.js"></script>
+  <script type="text/javascript">
+    document.addEventListener("page:change", function() {
+      console.log("page changed");
+    });
+
+    document.addEventListener("page:update", function() {
+      console.log("page updated");
+    });
+
+    document.addEventListener("page:restore", function() {
+      console.log("page restored");
+    });
+  </script>
+</head>
+<body class="page-other">
+  <ul>
+    <li><a href="/index.html">Home</a></li>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
I was trying to add "nested" sorting to my app, with query params like:

`http://localhost:3000/users?sort=account.email`

It breaks Turbolinks - it's treated like a "non-html" link. I added some tests and fixed it.
