### PR TITLE
Fix resetScrollPosition side effect with anchored

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -138,8 +138,8 @@ recallScrollPosition = (page) ->
   window.scrollTo page.positionX, page.positionY
 
 resetScrollPosition = ->
-  if document.location.hash
-    document.location.href = document.location.href
+  if element = document.location.hash and document.getElementById(document.location.hash.replace('#', ''))
+    element.scrollIntoView()
   else
     window.scrollTo 0, 0
 


### PR DESCRIPTION
In Chrome 34.0.1847.116, replace location.href with hash will append a history, then popstate will trigger current url, break restore behavior.
