### PR TITLE
Move event names into Turbolinks.EVENTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Turbolinks (master)
 
+*   Move events to `Turbolinks.EVENTS` and fire them from there.
+
+    *Robert Mosolgo*
+
 *   Add a `page:before-unload` event, triggered immediately before the page is changed.  The
     event is triggered regardless of where the page came from (server vs cache).
 


### PR DESCRIPTION
Hello, thanks for adding the `page:before-change` event! I forgot about a significant concern: `react-rails` should detect whether the `Turbolinks` environment supports `page:before-change`. I couldn't think of a good way to do this with the existing javascript, have I overlooked something?

I thought this would be a nice way to provide "feature sniffing": move events by name onto `Turbolinks.EVENTS`. Then we'll simply test for presence of `Turbolinks.EVENTS.BEFORE_CHANGE`. 

Does this sound reasonable to you @reed? 

I started up the rack server and poked around the links in `tests/index.html`. They seemed to behave as described and there were no errors in the JS console. Is there further testing I should do? 

Also, I added an entry to the changelog. I wasn't sure what the policy was there, but I'd be happy to remove it if you prefer to manage the changelog yourself!
