### PR TITLE
Don't set request_method cookie for GET requests

### DIFF
--- a/lib/turbolinks/cookies.rb
+++ b/lib/turbolinks/cookies.rb
@@ -1,10 +1,15 @@
 module Turbolinks
-  # Sets a request_method cookie containing the request method of the current request.
-  # The Turbolinks script will not initialize if this cookie is set to anything other than GET.
+  # For non-GET requests, sets a request_method cookie containing
+  # the request method of the current request. The Turbolinks script
+  # will not initialize if this cookie is set.
   module Cookies
     private
       def set_request_method_cookie
-        cookies[:request_method] = request.request_method
+        if request.get?
+          cookies.delete(:request_method)
+        else
+          cookies[:request_method] = request.request_method
+        end
       end
   end
 end


### PR DESCRIPTION
The Turbolinks script assumes a GET request if no cookie is present, so sending a cookie for GET is redundant. Turbolinks immediately deletes the cookie after reading it, so there is no risk of e.g. a PUT cookie value persisting through to the next GET request.

This makes it possible to eliminate cookies on public pages for caching via varnish, for example, as discussed in #269.
