### PR TITLE
add z-index in progress bar CSS override example

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The progress bar is implemented on the `<html>` element's pseudo `:before` eleme
 html.turbolinks-progress-bar::before {
   background-color: red !important;
   height: 5px !important;
+  z-index: 10000; /* Show progress bar above fixed navbar */
 }
 ```
 


### PR DESCRIPTION
It's pretty common that folks won't see the progress bar because they're using a fixed header/navbar. Without adding another sentence to the README, I felt that this would be a decent way to make folks aware of this.
