### PR TITLE
Give progress bar a high z-index value by default

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -514,6 +514,7 @@ class ProgressBar
       position: fixed;
       top: 0;
       left: 0;
+      z-index: 2000;
       background-color: #0076ff;
       height: 3px;
       opacity: #{@opacity};


### PR DESCRIPTION
This ensures that the progress bar is less likely to be obscured by other elements on the page. In particular, it fixes a problem where the Turbolinks progress bar gets hidden beneath Twitter Bootstrap's static top navbar (which has a z-index of 1000).

I chose 2000 for the default z-index value based on the example of the [pace.js minimal theme](https://github.com/HubSpot/pace/blob/master/themes/blue/pace-theme-minimal.css#L18), which is another implementation of a very similar progress bar.

[See issue 418](https://github.com/rails/turbolinks/issues/418#issuecomment-60974871) for more discussion.

This is an alternative to #422.
