### PR TITLE
Fix back button broken on redirect

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -161,7 +161,7 @@ reflectRedirectedUrl = ->
   if location = xhr.getResponseHeader 'X-XHR-Redirected-To'
     location = new ComponentUrl location
     preservedHash = if location.hasNoHash() then document.location.hash else ''
-    window.history.replaceState currentState, '', location.href + preservedHash
+    window.history.replaceState window.history.state, '', location.href + preservedHash
 
 crossOriginRedirect = ->
   redirect if (redirect = xhr.getResponseHeader('Location'))? and (new ComponentUrl(redirect)).crossOrigin()

--- a/test/config.ru
+++ b/test/config.ru
@@ -46,6 +46,10 @@ map "/slow-response" do
   run SlowResponse.new
 end
 
+map "/bounce" do
+  run Proc.new{ [200, { "X-XHR-Redirected-To" => "redirect1.html", "Content-Type" => "text/html" }, File.open( File.join( Root, "test", "redirect1.html" ) ) ] }
+end
+
 map "/" do
   run Rack::Directory.new(File.join(Root, "test"))
 end

--- a/test/index.html
+++ b/test/index.html
@@ -31,6 +31,7 @@
     <li><a href="/other.html" onclick="if(!confirm('follow link?')) { return false}">Confirm Fire Order</a></li>
     <li><a href="/reload.html"><span>New assets track </span></a></li>
     <li><a href="/dummy.gif?12345">Query Param Image Link</a></li>
+    <li><a href="/bounce">Redirect</a></li>
     <li><a href="#">Hash link</a></li>
     <li><a href="/reload.html#foo">New assets track with hash link</a></li>
     <li><h5>If you stop the server or go into airplane/offline mode</h5></li>

--- a/test/redirect1.html
+++ b/test/redirect1.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Home</title>
+  <script type="text/javascript" src="/js/turbolinks.js"></script>
+</head>
+<body class="page-other">
+  Should show /redirect1.html as path
+  <ul>
+    <li>Click <a href="/redirect2.html">Redirect 2</a></li>
+  </ul>
+
+</body>
+</html>

--- a/test/redirect2.html
+++ b/test/redirect2.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Home</title>
+  <script type="text/javascript" src="/js/turbolinks.js"></script>
+</head>
+<body class="page-other">
+  Hit back button twice. It should go back to home page.
+</body>
+</html>


### PR DESCRIPTION
Fixes regression introduced by 52284ea

Start Page 1
Click Link to Page 2
Server redirects to Page 3
Click Link to Page 4
Hit Back Button, Page 3 is Sown
Hit Back Button, Page 3 is Shown again, should be page 1

Without the fix, page 3 is shown again, though the URL does reflect Page 1.

The problem seems to relate to reflectRedirectUrl which uses currentState instead of window.history.state. currentState is set by changePage so calling reflectRedirectedUrl before changePage uses the wrong state.

Changing reflectRedirectedUrl to use window.history.state instead seems to resolve the issue.
