### PR TITLE
Fix XSS vulnerability for html files served up with "Content-Disposition attachment" headers

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -69,6 +69,7 @@ fetchReplacement = (url, onLoadFunction, showProgressBar = true) ->
       onLoadFunction?()
       triggerEvent EVENTS.LOAD
     else
+      progressBar?.done()
       document.location.href = crossOriginRedirect() or url.absolute
 
   if progressBar and showProgressBar
@@ -228,6 +229,10 @@ processResponse = ->
     (contentType = xhr.getResponseHeader('Content-Type'))? and
       contentType.match /^(?:text\/html|application\/xhtml\+xml|application\/xml)(?:;|$)/
 
+  downloadingFile = ->
+    (disposition = xhr.getResponseHeader('Content-Disposition'))? and
+      disposition.match /^attachment/
+
   extractTrackAssets = (doc) ->
     for node in doc.querySelector('head').childNodes when node.getAttribute?('data-turbolinks-track')?
       node.getAttribute('src') or node.getAttribute('href')
@@ -241,7 +246,7 @@ processResponse = ->
     [a, b] = [b, a] if a.length > b.length
     value for value in a when value in b
 
-  if not clientOrServerError() and validContent()
+  if not clientOrServerError() and validContent() and not downloadingFile()
     doc = createDocument xhr.responseText
     if doc and !assetsChanged doc
       return doc

--- a/test/attachment.html
+++ b/test/attachment.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<script language="javascript">alert("you shouldn't see this");</script>
+</body>
+</html>

--- a/test/config.ru
+++ b/test/config.ru
@@ -53,3 +53,11 @@ end
 map "/" do
   run Rack::Directory.new(File.join(Root, "test"))
 end
+
+map "/attachment.txt" do
+  run Rack::File.new(File.join(Root, "test", "attachment.html"), "Content-Type" => "text/plain")
+end
+
+map "/attachment.html" do
+  run Rack::File.new(File.join(Root, "test", "attachment.html"), "Content-Type" => "text/html", "Content-Disposition" => "attachment; filename=attachment.html")
+end

--- a/test/index.html
+++ b/test/index.html
@@ -34,6 +34,8 @@
     <li><a href="/bounce">Redirect</a></li>
     <li><a href="#">Hash link</a></li>
     <li><a href="/reload.html#foo">New assets track with hash link</a></li>
+    <li><a href="/attachment.txt">A text response should load normally</a></li>        
+    <li><a href="/attachment.html">An html response with Content-Disposition: attachment should load normally</a></li>    
     <li><h5>If you stop the server or go into airplane/offline mode</h5></li>
     <li><a href="/doesnotexist.html">A page with client error (4xx, rfc2616 sec. 10.4) should error out</a></li>
     <li><a href="/500">Also server errors (5xx, rfc2616 sec. 10.5) should error out</a></li>


### PR DESCRIPTION
This is a slightly more complete fix for the XSS issues identified in #195 that covers the case where untrusted user-uploaded html files are served up with one of the correct html Content-types and "Content-Disposition: attachment" headers (https://github.com/rails/turbolinks/issues/195#issuecomment-52037314). Test case included.
