### PR TITLE
Handle errors during onload by a hard page load

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -58,18 +58,23 @@ fetchReplacement = (url, onLoadFunction, showProgressBar = true) ->
   xhr.setRequestHeader 'Accept', 'text/html, application/xhtml+xml, application/xml'
   xhr.setRequestHeader 'X-XHR-Referer', referer
 
-  xhr.onload = ->
-    triggerEvent EVENTS.RECEIVE, url: url.absolute
+  handleError = -> document.location.href = url.absolute
 
-    if doc = processResponse()
-      reflectNewUrl url
-      reflectRedirectedUrl()
-      changePage extractTitleAndBody(doc)...
-      manuallyTriggerHashChangeForFirefox()
-      onLoadFunction?()
-      triggerEvent EVENTS.LOAD
-    else
-      document.location.href = crossOriginRedirect() or url.absolute
+  xhr.onload = ->
+    try
+      triggerEvent EVENTS.RECEIVE, url: url.absolute
+
+      if doc = processResponse()
+        reflectNewUrl url
+        reflectRedirectedUrl()
+        changePage extractTitleAndBody(doc)...
+        manuallyTriggerHashChangeForFirefox()
+        onLoadFunction?()
+        triggerEvent EVENTS.LOAD
+      else
+        document.location.href = crossOriginRedirect() or url.absolute
+    catch
+      handleError()
 
   if progressBar and showProgressBar
     xhr.onprogress = (event) =>
@@ -80,7 +85,7 @@ fetchReplacement = (url, onLoadFunction, showProgressBar = true) ->
       progressBar.advanceTo(percent)
 
   xhr.onloadend = -> xhr = null
-  xhr.onerror   = -> document.location.href = url.absolute
+  xhr.onerror   = handleError
 
   xhr.send()
 


### PR DESCRIPTION
Recently, Safari decided that you can only `pushState` 100 times. After that, `pushState` raises "SecurityError: DOM Exception 18". Here is some more info about this change:

https://forums.developer.apple.com/thread/36650
http://codepen.io/mortenolsendk/post/when-safari-broke-webapps

This patch adds error handling to the `onload` hook when Turbolinks receives a new page. This way, it will catch the pushState error. 

I was able to reproduce the error locally, and this patch "fixed" it for me. 

(Are you still taking patches for 2-5-stable?)