### PR TITLE
add scroll option for server side rendering

### DIFF
--- a/lib/turbolinks/redirection.rb
+++ b/lib/turbolinks/redirection.rb
@@ -50,7 +50,7 @@ module Turbolinks
     private
       def _extract_turbolinks_options!(options)
         turbolinks = options.delete(:turbolinks)
-        options = options.extract!(:keep, :change, :append, :prepend, :flush).delete_if { |_, value| value.nil? }
+        options = options.extract!(:keep, :change, :append, :prepend, :flush, :scroll).delete_if { |_, value| value.nil? }
 
         raise ArgumentError, "cannot combine :keep and :flush options" if options[:keep] && options[:flush]
 
@@ -70,6 +70,7 @@ module Turbolinks
         js_options[:prepend] = Array(options[:prepend]) if options[:prepend]
         js_options[:keep] = Array(options[:keep]) if options[:keep]
         js_options[:flush] = true if options[:flush]
+        js_options[:scroll] = options[:scroll] unless options[:scroll].nil?
 
         ", #{js_options.to_json}" if js_options.present?
       end

--- a/test/turbolinks/redirection_test.rb
+++ b/test/turbolinks/redirection_test.rb
@@ -58,6 +58,14 @@ class RedirectController < TestController
     redirect_to '/path', turbolinks: true, flush: false
   end
 
+  def redirect_to_path_with_turbolinks_and_scroll_true
+    redirect_to '/path', turbolinks: true, scroll: true
+  end
+
+  def redirect_to_path_with_turbolinks_and_scroll_false
+    redirect_to '/path', turbolinks: true, scroll: false
+  end
+
   def redirect_via_turbolinks_to_url_string
     ActiveSupport::Deprecation.silence do
       redirect_via_turbolinks_to 'http://example.com'
@@ -193,6 +201,16 @@ class RedirectionTest < ActionController::TestCase
     assert_raises ArgumentError do
       @controller.redirect_to '/path', keep: :foo, flush: true
     end
+  end
+
+  def test_redirect_to_with_turbolinks_and_scroll_true
+    get :redirect_to_path_with_turbolinks_and_scroll_true
+    assert_turbolinks_visit 'http://test.host/path', '{"scroll":true}'
+  end
+
+  def test_redirect_to_with_turbolinks_and_scroll_false
+    get :redirect_to_path_with_turbolinks_and_scroll_false
+    assert_turbolinks_visit 'http://test.host/path', '{"scroll":false}'
   end
 
   def test_redirect_via_turbolinks_to_url_string


### PR DESCRIPTION
When a user submits a remote form and the server sends the response to redirect to the same page via turbolinks, the scroll position of the browser window will be reset to 0.

Currently, turbolinks only supports scroll option on client side. This commit adds scroll option for server side.