### PR TITLE
update travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,14 @@
 language: ruby
 
 before_install:
-  - mkdir travis-phantomjs
-  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
-  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
-  - export PATH=$PWD/travis-phantomjs:$PATH
   - npm install
 
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.7
-  - 2.2.3
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
 
 sudo: false
 cache: bundler
@@ -30,8 +27,10 @@ gemfile:
 matrix:
   exclude:
     - gemfile: Gemfile.rails50
-      rvm: 1.9.3
-    - gemfile: Gemfile.rails50
       rvm: 2.0.0
     - gemfile: Gemfile.rails50
       rvm: 2.1.7
+    - gemfile: Gemfile.rails40
+      rvm: 2.4.2
+    - gemfile: Gemfile.rails41
+      rvm: 2.4.2

--- a/Gemfile.rails50
+++ b/Gemfile.rails50
@@ -1,8 +1,4 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'rails', github: 'rails/rails', branch: 'master'
-gem 'arel', github: 'rails/arel', branch: 'master'
-gem 'rack', github: 'rack/rack', branch: 'master'
-gem 'sprockets-rails', github: 'rails/sprockets-rails', branch: 'master'
-gem 'sprockets', github: 'rails/sprockets', branch: 'master'
+gem 'rails', '~> 5.0.0'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "repository": {
     "type": "git",
-    "url": "https://github.com/rails/turbolinks.git"
+    "url": "https://github.com/rails/turbolinks-classic.git"
   },
   "devDependencies": {
     "mocha": "~2.2.0",


### PR DESCRIPTION
This drops Ruby 1.9 as it's just too old now to work out of the box with the current dependencies.